### PR TITLE
Use uint64 for Page valid bitlist and reuse hasher and buffers

### DIFF
--- a/cannon/mipsevm/memory/binary_tree.go
+++ b/cannon/mipsevm/memory/binary_tree.go
@@ -40,6 +40,10 @@ func (m *BinaryTreeIndex) Invalidate(addr Word) {
 	gindex := (uint64(1) << (WordSize - PageAddrSize)) | uint64(addr>>PageAddrSize)
 
 	for gindex > 0 {
+		n := m.nodes[gindex]
+		if n != nil {
+			PutByte32(n)
+		}
 		m.nodes[gindex] = nil
 		gindex >>= 1
 	}
@@ -70,9 +74,10 @@ func (m *BinaryTreeIndex) MerkleizeSubtree(gindex uint64) [32]byte {
 	}
 	left := m.MerkleizeSubtree(gindex << 1)
 	right := m.MerkleizeSubtree((gindex << 1) | 1)
-	r := HashPair(left, right)
-	m.nodes[gindex] = &r
-	return r
+	r := GetByte32()
+	HashPairNodes(r, &left, &right)
+	m.nodes[gindex] = r
+	return *r
 }
 
 func (m *BinaryTreeIndex) MerkleProof(addr Word) (out [MemProofSize]byte) {
@@ -112,6 +117,10 @@ func (m *BinaryTreeIndex) AddPage(pageIndex Word) {
 	// make nodes to root
 	k := (1 << PageKeySize) | uint64(pageIndex)
 	for k > 0 {
+		n := m.nodes[k]
+		if n != nil {
+			PutByte32(n)
+		}
 		m.nodes[k] = nil
 		k >>= 1
 	}

--- a/cannon/mipsevm/memory/hasher.go
+++ b/cannon/mipsevm/memory/hasher.go
@@ -1,0 +1,74 @@
+package memory
+
+import (
+	"sync"
+
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// Byte32Pool is a sync.Pool for [32]byte slices
+var Byte32Pool = sync.Pool{
+	New: func() interface{} {
+		var b [32]byte
+		return &b // Return a pointer to avoid extra allocations
+	},
+}
+
+// GetByte32 retrieves a *[32]byte from the pool
+func GetByte32() *[32]byte {
+	return Byte32Pool.Get().(*[32]byte)
+}
+
+// PutByte32 returns a *[32]byte to the pool
+func PutByte32(b *[32]byte) {
+	// Optional: Zero the array before putting it back
+	*b = [32]byte{}
+	Byte32Pool.Put(b)
+}
+
+var hashPool = sync.Pool{
+	New: func() interface{} {
+		return crypto.NewKeccakState()
+	},
+}
+
+func GetHasher() crypto.KeccakState {
+	return hashPool.Get().(crypto.KeccakState)
+}
+
+func PutHasher(h crypto.KeccakState) {
+	h.Reset()
+	hashPool.Put(h)
+}
+
+func HashPairNodes(out *[32]byte, left, right *[32]byte) {
+	h := GetHasher()
+	h.Write(left[:])
+	h.Write(right[:])
+	h.Read(out[:])
+	PutHasher(h)
+}
+
+func HashData(out *[32]byte, data ...[]byte) {
+	h := GetHasher()
+	for _, b := range data {
+		h.Write(b)
+	}
+	h.Read(out[:])
+	PutHasher(h)
+}
+
+func HashPair(left, right [32]byte) [32]byte {
+	out := crypto.Keccak256Hash(left[:], right[:])
+	//fmt.Printf("0x%x 0x%x -> 0x%x\n", left, right, out)
+	return out
+}
+
+var zeroHashes = func() [256][32]byte {
+	// empty parts of the tree are all zero. Precompute the hash of each full-zero range sub-tree level.
+	var out [256][32]byte
+	for i := 1; i < 256; i++ {
+		out[i] = HashPair(out[i-1], out[i-1])
+	}
+	return out
+}()

--- a/cannon/mipsevm/memory/page.go
+++ b/cannon/mipsevm/memory/page.go
@@ -9,8 +9,6 @@ import (
 	"fmt"
 	"io"
 	"sync"
-
-	"github.com/ethereum/go-ethereum/crypto"
 )
 
 var zlibWriterPool = sync.Pool{
@@ -66,47 +64,66 @@ type CachedPage struct {
 	Data *Page
 	// intermediate nodes only
 	Cache [PageSize / 32][32]byte
-	// true if the intermediate node is valid
-	Ok [PageSize / 32]bool
+	// bit set to 1 if the intermediate node is valid
+	OkLow, OkHigh uint64 // size is PageSize / 32 == 64 + 64 == 128
 }
 
 func (p *CachedPage) invalidate(pageAddr Word) {
 	if pageAddr >= PageSize {
 		panic("invalid page addr")
 	}
-	k := (1 << PageAddrSize) | pageAddr
-	// first cache layer caches nodes that has two 32 byte leaf nodes.
+
+	k := uint64((1 << PageAddrSize) | pageAddr)
 	k >>= 5 + 1
+
 	for k > 0 {
-		p.Ok[k] = false
+		mask := uint64(1) << (k & 63)   // Bitmask
+		isHigh := k >> 6                // 1 if k >= 64, 0 if k < 64
+		p.OkLow &^= mask * (1 - isHigh) // Zero bit in OkLow if isHigh == 0
+		p.OkHigh &^= mask * isHigh      // Zero bit in OkHigh if isHigh == 1
 		k >>= 1
 	}
 }
 
+func (p *CachedPage) getBit(k uint64) bool {
+	if k < 64 {
+		return (p.OkLow & (1 << k)) != 0
+	}
+	return (p.OkHigh & (1 << (k - 64))) != 0
+}
+
+func (p *CachedPage) setBit(k uint64) {
+	mask := uint64(1) << (k & 63)  // Bitmask
+	isHigh := k >> 6               // 1 if k >= 64, 0 if k < 64
+	p.OkLow |= mask * (1 - isHigh) // Set in OkLow if isHigh == 0
+	p.OkHigh |= mask * isHigh      // Set in OkHigh if isHigh == 1
+}
+
 func (p *CachedPage) InvalidateFull() {
-	p.Ok = [PageSize / 32]bool{} // reset everything to false
+	p.OkHigh = 0
+	p.OkLow = 0
 }
 
 func (p *CachedPage) MerkleRoot() [32]byte {
 	// hash the bottom layer
 	for i := uint64(0); i < PageSize; i += 64 {
 		j := PageSize/32/2 + i/64
-		if p.Ok[j] {
+		if p.getBit(j) {
 			continue
 		}
-		p.Cache[j] = crypto.Keccak256Hash(p.Data[i : i+64])
+		HashData(&p.Cache[j], p.Data[i:i+64])
 		//fmt.Printf("0x%x 0x%x -> 0x%x\n", p.Data[i:i+32], p.Data[i+32:i+64], p.Cache[j])
-		p.Ok[j] = true
+		p.setBit(j)
 	}
 
 	// hash the cache layers
 	for i := PageSize/32 - 2; i > 0; i -= 2 {
 		j := i >> 1
-		if p.Ok[j] {
+		if p.getBit(uint64(j)) {
 			continue
 		}
-		p.Cache[j] = HashPair(p.Cache[i], p.Cache[i+1])
-		p.Ok[j] = true
+		HashPairNodes(&p.Cache[j], &p.Cache[i], &p.Cache[i+1])
+		p.setBit(uint64(j))
 	}
 
 	return p.Cache[1]
@@ -120,7 +137,7 @@ func (p *CachedPage) MerkleizeSubtree(gindex uint64) [32]byte {
 		}
 		// it's pointing to a bottom node
 		nodeIndex := gindex & (PageAddrMask >> 5)
-		return *(*[32]byte)(p.Data[nodeIndex*32 : nodeIndex*32+32])
+		return *(*[32]byte)(p.Data[nodeIndex*32 : nodeIndex*32+32 : nodeIndex*32+32])
 	}
 	return p.Cache[gindex]
 }


### PR DESCRIPTION
There is currently a lot of heap allocation during Merklization and just keeping track of intermediate nodes. By reclaiming and reusing buffers when marking the tree's merkle cache as well as reusing the Sha256 hasher, we can save on a lot of allocations.

In addition, in CachedPage, a bitlist is managed to keep track of whether intermediate nodes are valid or not. By using integers instead of an array of bools, we can do some bit magic to branchlessly maintain this bitlist. Also by doing this, we also avoid the Go runtime's bounds checking every time we mark a bit valid or not. 